### PR TITLE
Introduce distinction between document resource and node resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist/
 .mypy_cache/
 .vscode/
+.idea/
 docs/_*
 docs/make.bat
 **.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+services:
+    - docker
+python:
+    - "3.6"
+before_install:
+    - docker pull existdb/existdb:4.7.1
+    - docker run -it -d -p 8080:8080 -p 8443:8443 --name exist-4.7.1 existdb/existdb:4.7.1
+install:
+    - travis_retry pip install poetry
+    - travis_retry poetry install
+script:
+    - poetry run pytest

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -110,23 +110,6 @@ class DocumentResource(Resource):
     """
     A representation of an eXist document node
     """
-    def __init__(
-            self,
-            exist_client: "ExistClient",
-            query_result: Optional[QueryResultItem] = None
-    ):
-        """
-        :param exist_client: The client to which the resource is coupled.
-        :query_result: A tuple containing the absolute resource ID, node ID
-                       and the node of the resource.
-        """
-        if query_result.node_id == "1":
-            super().__init__(exist_client, query_result)
-        else:
-            raise ValueError(
-                f"Invalid value of node_id {query_result.node_id}. "
-                f"On document nodes this value can only be '1'."
-            )
 
     def delete(self):
         self._exist_client.delete_document(document_path=self.document_path)

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -359,31 +359,31 @@ class ExistClient:
         return result_node.xpath("./*")[0].detach()
 
     def update_node(
-        self, updated_node: str, abs_resource_id: str, node_id: str
+        self, data: str, abs_resource_id: str, node_id: str
     ) -> None:
         """
         Replace a sub-document node with an updated version.
 
-        :param updated_node: The node to replace the old one with.
+        :param data: A well-formed XML string containing the node to replace the old one with.
         :param abs_resource_id: The absolute resource ID pointing to the document containing the node.
         :param node_id: The node ID locating the node inside the containing document.
         """
         self.query(
             f"update replace util:node-by-id(util:get-resource-by-absolute-id({abs_resource_id}), '{node_id}')"
-            f"with {updated_node}"
+            f"with {data}"
         )
 
     def update_document(
-        self, updated_node: str, document_path: str
+        self, data: str, document_path: str
     ) -> None:
         """
         Replace a document root node with an updated version.
 
-        :param updated_node: The node to replace the old one with.
+        :param data: A well-formed XML string containing the node to replace the old one with.
         :param document_path: The path pointing to the document (relative to the REST endpoint, e. g. '/db/foo/bar')
         """
         url = self._join_paths(self.base_url, "rest", document_path)
-        self._put_request(url, updated_node)
+        self._put_request(url, data)
 
     def delete_node(
             self, abs_resource_id: str, node_id: str = ""

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -8,7 +8,7 @@ from typing import List, Optional, Tuple
 
 import delb
 import requests
-from abc import ABC
+from abc import ABC, abstractmethod
 from lxml import etree  # type: ignore
 from uuid import uuid4
 from requests.auth import HTTPBasicAuth
@@ -71,6 +71,14 @@ class Resource(ABC):
         self.node = self._exist_client.retrieve_resource(
             abs_resource_id=self._abs_resource_id, node_id=self._node_id
         )
+
+    @abstractmethod
+    def update_push(self):
+        pass
+
+    @abstractmethod
+    def delete(self):
+        pass
 
     @property
     def abs_resource_id(self):

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -101,7 +101,7 @@ class Resource(ABC):
     @property
     def document_path(self):
         """
-        The node ID locating the node relative to the containing document.
+        The resource path pointing to the document.
         """
         return self._document_path
 

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -328,7 +328,7 @@ class ExistClient:
 
         :param abs_resource_id: The absolute resource ID pointing to the document.
         :param node_id: The node ID locating a node inside a document (optional).
-        :return: The queried node as a ``delb.TagNode`` object.
+        :return: The queried node as a ``Resource`` object.
         """
         path = self.query(
             f"let $node := util:get-resource-by-absolute-id({abs_resource_id})"

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -247,7 +247,10 @@ class ExistClient:
     def _parse_item(node: delb.TagNode) -> QueryResultItem:
         content_node = node.first_child
         assert isinstance(content_node, delb.TagNode)
-        return node["absid"], node["nodeid"], node["path"], content_node.detach()
+        return QueryResultItem(
+            node["absid"], node["nodeid"],
+            node["path"], content_node.detach()
+        )
 
     @property
     def base_url(self) -> str:

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -193,12 +193,11 @@ class ExistClient:
         return "/".join(s.strip("/") for s in args)
 
     def _get_request(self, url: str, query: Optional[str] = None, wrap: bool = True) -> bytes:
-        if wrap:
-            wrap_value = "yes"
-        else:
-            wrap_value = "no"
         if query:
-            params = {"_howmany": "0", "_indent": "no", "_wrap": wrap_value, "_query": query}
+            params = {
+                "_howmany": "0", "_indent": "no",
+                "_wrap": "yes" if wrap else "no", "_query": query
+            }
         else:
             params = {}
 

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -136,7 +136,7 @@ class DocumentResource(Resource):
 
     def update_push(self):
         self._exist_client.update_document(
-            updated_node=str(self.node),
+            data=str(self.node),
             document_path=self.document_path,
         )
 
@@ -155,7 +155,7 @@ class NodeResource(Resource):
 
     def update_push(self):
         self._exist_client.update_node(
-            updated_node=str(self.node),
+            data=str(self.node),
             abs_resource_id=self._abs_resource_id,
             node_id=self._node_id,
         )

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -323,11 +323,11 @@ class ExistClient:
         resources = []
         for item in results_node.css_select("pyexist-result"):
             query_result = self._parse_item(item)
-            if query_result.node_id == "1":
-                resource = DocumentResource(exist_client=self, query_result=query_result)
-            else:
-                resource = NodeResource(exist_client=self, query_result=query_result)
-            resources.append(resource)
+            resources.append(
+                DocumentResource(exist_client=self, query_result=query_result)
+                if query_result.node_id == "1"
+                else NodeResource(exist_client=self, query_result=query_result)
+            )
         return resources
 
     def retrieve_resource(

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -184,7 +184,7 @@ class ExistClient:
             user: str = DEFAULT_USER,
             password: str = DEFAULT_PASSWORD,
             prefix: str = "exist",
-            parser:etree.XMLParser = DEFAULT_PARSER
+            parser: etree.XMLParser = DEFAULT_PARSER
     ):
         self._root_collection = "/"
         self.host = host
@@ -288,7 +288,6 @@ class ExistClient:
         Make a database query using XQuery
 
         :param query_expression: XQuery expression
-        :param parser: Parser used for processing XML
         :return: The query result as a ``delb.Document`` object.
         """
         response_string = self._get_request(
@@ -357,28 +356,7 @@ class ExistClient:
             result_node = self.query(
                 query_expression=f"util:get-resource-by-absolute-id({abs_resource_id})"
             )
-        return result_node.xpath("./*")[0].detach()  # TODO: Performance check?
-
-    def update_resource(
-        self, updated_node: str, abs_resource_id: str, node_id: str = ""
-    ) -> None:
-        """
-        Replace a database resource with an updated one.
-
-        :param abs_resource_id: The absolute resource ID pointing to the document.
-        :param node_id: The node ID locating a node inside a document (optional).
-        """
-        if node_id:
-            self.query(
-                f"let $node := util:node-by-id("
-                f"util:get-resource-by-absolute-id({abs_resource_id}), '{node_id}') "
-                f"return update replace $node with {updated_node}"
-            )
-        else:
-            self.query(
-                f"let $node := util:get-resource-by-absolute-id({abs_resource_id}) "
-                f"return update replace $node with {updated_node}"
-            )
+        return result_node.xpath("./*")[0].detach()
 
     def update_node(
         self, updated_node: str, abs_resource_id: str, node_id: str

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -57,7 +57,7 @@ class Resource(ABC):
         else:
             self._abs_resource_id = self._node_id = ""
             self.node = None
-            self._document_path = None
+            self._document_path = ''
 
     def __str__(self):
         return str(self.node)

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -3,17 +3,15 @@
     :synopsis: A module containing basic tools for connecting to eXist.
 """
 
+from abc import ABC, abstractmethod
+from typing import List, Optional, NamedTuple
 from urllib.parse import urljoin
-from typing import List, Optional, Tuple
+from uuid import uuid4
 
 import delb
 import requests
-from abc import ABC, abstractmethod
 from lxml import etree  # type: ignore
-from uuid import uuid4
 from requests.auth import HTTPBasicAuth
-from typing import NamedTuple
-from requests.exceptions import HTTPError
 
 from snakesist.errors import ExistAPIError
 

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -109,7 +109,13 @@ class DocumentResource(Resource):
         :query_result: A tuple containing the absolute resource ID, node ID
                        and the node of the resource.
         """
-        super().__init__(exist_client, query_result)
+        if query_result.node_id == "1":
+            super().__init__(exist_client, query_result)
+        else:
+            raise ValueError(
+                f"Invalid value of node_id {query_result.node_id}. "
+                f"On document nodes this value can only be '1'."
+            )
 
     def delete(self):
         """
@@ -133,17 +139,6 @@ class NodeResource(Resource):
     """
     A representation of an eXist node at the sub-document level
     """
-    def __init__(
-            self,
-            exist_client: "ExistClient",
-            query_result: Optional[QueryResultItem] = None
-    ):
-        """
-        :param exist_client: The client to which the resource is coupled.
-        :query_result: A tuple containing the absolute resource ID, node ID
-                       and the node of the resource.
-        """
-        super().__init__(exist_client, query_result)
 
     def delete(self):
         """

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -48,7 +48,7 @@ class Resource(ABC):
         :query_result: A tuple containing the absolute resource ID, node ID
                        and the node of the resource.
         """
-        self.node: Optional[delb.TagNode]
+        self.node: Optional[delb.NodeBase]
 
         self._exist_client = exist_client
 

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -74,10 +74,16 @@ class Resource(ABC):
 
     @abstractmethod
     def update_push(self):
+        """
+        Write the resource object to the database.
+        """
         pass
 
     @abstractmethod
     def delete(self):
+        """
+        Remove the node from the database.
+        """
         pass
 
     @property
@@ -118,17 +124,11 @@ class DocumentResource(Resource):
             )
 
     def delete(self):
-        """
-        Remove the document from the database.
-        """
         self._exist_client.delete_document(path=self.path)
         self._node_id = None
         self._abs_resource_id = None
 
     def update_push(self):
-        """
-        Write the resource object to the database.
-        """
         self._exist_client.update_document(
             updated_node=str(self.node),
             path=self.path,
@@ -141,9 +141,6 @@ class NodeResource(Resource):
     """
 
     def delete(self):
-        """
-        Remove the node from the database.
-        """
         self._exist_client.delete_node(
             abs_resource_id=self._abs_resource_id, node_id=self._node_id
         )
@@ -151,9 +148,6 @@ class NodeResource(Resource):
         self._abs_resource_id = None
 
     def update_push(self):
-        """
-        Write the resource object to the database.
-        """
         self._exist_client.update_node(
             updated_node=str(self.node),
             abs_resource_id=self._abs_resource_id,

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -208,8 +208,7 @@ class ExistClient:
             params=params
         )
 
-        if response.status_code != requests.codes.ok:
-            response.raise_for_status()
+        response.raise_for_status()
 
         return response.content
 

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -12,12 +12,16 @@ from abc import ABC
 from lxml import etree  # type: ignore
 from uuid import uuid4
 from requests.auth import HTTPBasicAuth
+from typing import NamedTuple
 from requests.exceptions import HTTPError
 
 from snakesist.errors import ExistAPIError
 
 
-QueryResultItem = Tuple[str, str, str, delb.TagNode]
+QueryResultItem = NamedTuple(
+    "QueryResultItem",
+    [("absolute_id", str), ("node_id", str), ("path", str), ("node", delb.TagNode)]
+)
 
 
 DEFAULT_HOST = "localhost"
@@ -325,7 +329,7 @@ class ExistClient:
         resources = []
         for item in results_node.css_select("pyexist-result"):
             query_result = self._parse_item(item)
-            if query_result[1] == "1":
+            if query_result.node_id == "1":
                 resource = DocumentResource(exist_client=self, query_result=query_result)
             else:
                 resource = NodeResource(exist_client=self, query_result=query_result)

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -113,9 +113,9 @@ class DocumentResource(Resource):
 
     def delete(self):
         self._exist_client.delete_document(document_path=self.document_path)
-        self._node_id = None
-        self._abs_resource_id = None
-        self._document_path = None
+        self._node_id = ""
+        self._abs_resource_id = ""
+        self._document_path = ""
 
     def update_push(self):
         self._exist_client.update_document(
@@ -133,8 +133,8 @@ class NodeResource(Resource):
         self._exist_client.delete_node(
             abs_resource_id=self._abs_resource_id, node_id=self._node_id
         )
-        self._node_id = None
-        self._abs_resource_id = None
+        self._node_id = ""
+        self._abs_resource_id = ""
 
     def update_push(self):
         self._exist_client.update_node(

--- a/tests/test_exist_client.py
+++ b/tests/test_exist_client.py
@@ -32,7 +32,7 @@ def test_exist_client_create_resource_malformed(db):
         db.create_resource("/foo", new_node)
 
 
-def test_exist_update_document(db):
+def test_exist_client_update_document(db):
     new_node = '<example id="t2">wow a document node</example>'
     updated_node = '<example id="t2">wow a NEW document node</example>'
     db.create_resource("/foo", new_node)
@@ -44,7 +44,7 @@ def test_exist_update_document(db):
     assert node == updated_node
 
 
-def test_exist_update_node(db):
+def test_exist_client_update_node(db):
     new_node = '<example id="t3">i am a <subnode>child</subnode></example>'
     updated_node = '<subnode>child indeed</subnode>'
     db.create_resource("/foo", new_node)
@@ -58,7 +58,7 @@ def test_exist_update_node(db):
     assert node == updated_node
 
 
-def test_exist_delete_node(db):
+def test_exist_client_delete_node(db):
     new_node = '<example id="t4">i stay<deletee> and i am to be deleted</deletee></example>'
     remaining_node = '<example id="t4">i stay</example>'
     db.create_resource("/foo", new_node)
@@ -72,7 +72,7 @@ def test_exist_delete_node(db):
     assert node == remaining_node
 
 
-def test_exist_delete_document(db):
+def test_exist_client_delete_document(db):
     new_node = '<example id="t5">i am to be deleted</example>'
     db.create_resource("/foo", new_node)
     xq = "let $node := //example[@id='t5'] return util:collection-name($node) || '/' || util:document-name($node)"
@@ -83,10 +83,22 @@ def test_exist_delete_document(db):
     assert node == ""
 
 
-def test_exist_retrieve_resource(db):
+def test_exist_client_retrieve_resource(db):
     new_node = '<example id="t6">retrieve me!</example>'
     db.create_resource("/foo", new_node)
     xq = "let $node := //example[@id='t6'] return util:absolute-resource-id($node)"
     abs_id = requests.get(f"{BASE_URL}&_query={xq}").content.decode()
     retrieved_node = db.retrieve_resource(abs_resource_id=abs_id)
     assert new_node == str(retrieved_node)
+
+
+def test_exist_client_retrieve_resources(db):
+    node_resource = '<p>retrieve me first!</p>'
+    node_resource_doc = f'<example id="t7">{node_resource}</example>'
+    db.create_resource("/foo", node_resource_doc)
+    document_resource = '<p>retrieve me too!</p>'
+    db.create_resource("/foo", document_resource)
+    retrieved_nodes = db.retrieve_resources("//p")
+    retrieved_nodes_str = [str(node) for node in retrieved_nodes]
+    assert node_resource in retrieved_nodes_str
+    assert document_resource in retrieved_nodes_str

--- a/tests/test_exist_client.py
+++ b/tests/test_exist_client.py
@@ -58,3 +58,26 @@ def test_exist_update_node(db):
     assert node == updated_node
 
 
+def test_exist_delete_node(db):
+    new_node = '<example id="t4">i stay<deletee> and i am to be deleted</deletee></example>'
+    remaining_node = '<example id="t4">i stay</example>'
+    db.create_resource("/foo", new_node)
+    xq = "let $node := //deletee return util:absolute-resource-id($node)"
+    abs_res_id = requests.get(f"{BASE_URL}&_query={xq}").content.decode()
+    xq = "let $node := //deletee return util:node-id($node)"
+    node_id = requests.get(f"{BASE_URL}&_query={xq}").content.decode()
+    db.delete_node(abs_res_id, node_id)
+    response = requests.get(f"{BASE_URL}&_query=//example[@id='t4']")
+    node = response.content.decode()
+    assert node == remaining_node
+
+
+def test_exist_delete_document(db):
+    new_node = '<example id="t5">i am to be deleted</example>'
+    db.create_resource("/foo", new_node)
+    xq = "let $node := //example[@id='t5'] return util:collection-name($node) || '/' || util:document-name($node)"
+    path = requests.get(f"{BASE_URL}&_query={xq}").content.decode()
+    db.delete_document(path)
+    response = requests.get(f"{BASE_URL}&_query=//example[@id='t5']")
+    node = response.content.decode()
+    assert node == ""

--- a/tests/test_exist_client.py
+++ b/tests/test_exist_client.py
@@ -15,11 +15,11 @@ def db():
     db = ExistClient()
     db.root_collection = ROOT_COLL
     yield db
-    # requests.get(f"{BASE_URL}&_query=xmldb:remove('{ROOT_COLL}')")
+    requests.get(f"{BASE_URL}&_query=xmldb:remove('{ROOT_COLL}')")
 
 
 def test_exist_client_create_resource_wellformed(db):
-    new_node = '<example id="t1">wow a document node</example>'
+    new_node = '<example id="t1">wow a <foo>document</foo> node</example>'
     db.create_resource("/foo", new_node)
     response = requests.get(f"{BASE_URL}&_query=//example[@id='t1']")
     node = response.content.decode()
@@ -45,15 +45,16 @@ def test_exist_update_document(db):
 
 
 def test_exist_update_node(db):
-    new_node = '<example id="t3"><example id="t4">i am a child</example></example>'
-    updated_node = '<example id="t4">i am a child indeed</example>'
+    new_node = '<example id="t3">i am a <subnode>child</subnode></example>'
+    updated_node = '<subnode>child indeed</subnode>'
     db.create_resource("/foo", new_node)
-    xq = "let $node := //example[@id='t4'] return util:absolute-resource-id($node)"
+    xq = "let $node := //subnode return util:absolute-resource-id($node)"
     abs_res_id = requests.get(f"{BASE_URL}&_query={xq}").content.decode()
-    xq = "let $node := //example[@id='t4'] return util:node-id($node)"
+    xq = "let $node := //subnode return util:node-id($node)"
     node_id = requests.get(f"{BASE_URL}&_query={xq}").content.decode()
     db.update_node(updated_node, abs_res_id, node_id)
-    response = requests.get(f"{BASE_URL}&_query=//example[@id='t4']")
+    response = requests.get(f"{BASE_URL}&_query=//subnode")
     node = response.content.decode()
     assert node == updated_node
+
 

--- a/tests/test_exist_client.py
+++ b/tests/test_exist_client.py
@@ -81,3 +81,12 @@ def test_exist_delete_document(db):
     response = requests.get(f"{BASE_URL}&_query=//example[@id='t5']")
     node = response.content.decode()
     assert node == ""
+
+
+def test_exist_retrieve_resource(db):
+    new_node = '<example id="t6">retrieve me!</example>'
+    db.create_resource("/foo", new_node)
+    xq = "let $node := //example[@id='t6'] return util:absolute-resource-id($node)"
+    abs_id = requests.get(f"{BASE_URL}&_query={xq}").content.decode()
+    retrieved_node = db.retrieve_resource(abs_resource_id=abs_id)
+    assert new_node == str(retrieved_node)

--- a/tests/test_exist_client.py
+++ b/tests/test_exist_client.py
@@ -1,8 +1,7 @@
 import pytest
-import urllib
 import requests
 from requests.exceptions import HTTPError
-from snakesist.exist_client import Resource, ExistClient
+from snakesist.exist_client import ExistClient
 
 ROOT_COLL = "/db/tests"
 BASE_URL = f"http://admin:@localhost:8080/exist/rest{ROOT_COLL}?_wrap=no&_indent=no"
@@ -16,18 +15,45 @@ def db():
     db = ExistClient()
     db.root_collection = ROOT_COLL
     yield db
-    requests.get(f"{BASE_URL}&_query=xmldb:remove('{ROOT_COLL}')")
+    # requests.get(f"{BASE_URL}&_query=xmldb:remove('{ROOT_COLL}')")
 
 
 def test_exist_client_create_resource_wellformed(db):
     new_node = '<example id="t1">wow a document node</example>'
     db.create_resource("/foo", new_node)
     response = requests.get(f"{BASE_URL}&_query=//example[@id='t1']")
-    node = response.content
-    assert node.decode() == new_node
+    node = response.content.decode()
+    assert node == new_node
 
 
 def test_exist_client_create_resource_malformed(db):
     new_node = '<exapl id="t1">tags do not match</example>'
     with pytest.raises(HTTPError):
         db.create_resource("/foo", new_node)
+
+
+def test_exist_update_document(db):
+    new_node = '<example id="t2">wow a document node</example>'
+    updated_node = '<example id="t2">wow a NEW document node</example>'
+    db.create_resource("/foo", new_node)
+    xq = "let $node := //example[@id='t2'] return util:collection-name($node) || '/' || util:document-name($node)"
+    path = requests.get(f"{BASE_URL}&_query={xq}").content.decode()
+    db.update_document(updated_node, path)
+    response = requests.get(f"{BASE_URL}&_query=//example[@id='t2']")
+    node = response.content.decode()
+    assert node == updated_node
+
+
+def test_exist_update_node(db):
+    new_node = '<example id="t3"><example id="t4">i am a child</example></example>'
+    updated_node = '<example id="t4">i am a child indeed</example>'
+    db.create_resource("/foo", new_node)
+    xq = "let $node := //example[@id='t4'] return util:absolute-resource-id($node)"
+    abs_res_id = requests.get(f"{BASE_URL}&_query={xq}").content.decode()
+    xq = "let $node := //example[@id='t4'] return util:node-id($node)"
+    node_id = requests.get(f"{BASE_URL}&_query={xq}").content.decode()
+    db.update_node(updated_node, abs_res_id, node_id)
+    response = requests.get(f"{BASE_URL}&_query=//example[@id='t4']")
+    node = response.content.decode()
+    assert node == updated_node
+


### PR DESCRIPTION
* `DocumentResource` and `NodeResource` are introduced as child classes of `Resource` as discussed in issue #2 
* `Resource` is not instantiated anymore and becomes a base class
* New deletion and updating methods are introduced pertaining to the two new distinct classes
* The previously mentioned methods require the introduction of the resource path as a fourth item inside the `QueryResult` structure, which has been extended accordingly
* The new methods have passing unit tests for eXist 4.7 (tests run on a live db)