### PR TITLE
Release 0.1.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,12 +30,7 @@ Usage example
 
     from snakesist import ExistClient
 
-    db = ExistClient(
-        host='my.existdbinstance.org',  # defaults to 'localhost'
-        port='80',  # defaults to 8080
-        user='foo_bar',  # defaults to 'admin'
-        passwordw='f0ob4r'  # defaults to ''
-    )
+    db = ExistClient()
 
     db.root_collection = '/db/foo/bar'
     # the client will only query from this point downwards

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snakesist"
-version = "0.1.0"
+version = "0.1.1"
 description = "A Python database interface for eXist-db"
 license = "MIT"
 authors = ["Theodor Costea <theo.costea@gmail.com>", "Frank Sachsenheim <funkyfuture@riseup.net>"]

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -230,7 +230,7 @@ class ExistClient:
         assert isinstance(content_node, delb.TagNode)
         return QueryResultItem(
             node["absid"], node["nodeid"],
-            node["path"], content_node.detach()
+            node["path"], content_node
         )
 
     @property


### PR DESCRIPTION
This release brings only a minor change affecting performance (#10): A call to the delb `detach()` method was causing a substantial bottleneck. This reversion moves the problem back the level of memory consumption, which is now back to the sub-optimal state in `0.1.0-b1`.