### PR TITLE
Migrate to plugin architecture

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -72,11 +72,12 @@ description = "A library that provides an ergonomic model for XML encoded text d
 name = "delb"
 optional = false
 python-versions = ">=3.6"
-version = "0.1.2"
+version = "0.2.dev2"
 
 [package.dependencies]
 cssselect = "*"
 lxml = "*"
+pluggy = ">=0.13.0,<0.14.0"
 
 [[package]]
 category = "dev"
@@ -103,7 +104,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.1.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Read metadata from Python packages"
 marker = "python_version < \"3.8\""
 name = "importlib-metadata"
@@ -142,7 +143,7 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 version = "1.1.1"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
@@ -183,7 +184,7 @@ pyparsing = ">=2.0.2"
 six = "*"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
 optional = false
@@ -397,7 +398,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
 version = "1.25.6"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 marker = "python_version < \"3.8\""
 name = "zipp"
@@ -409,7 +410,7 @@ version = "0.6.0"
 more-itertools = "*"
 
 [metadata]
-content-hash = "fdceba6e6cc10579265e344c0ff858b0200205897223c754918357e9886ebd77"
+content-hash = "07fc5387b15e76b4bf26d51b3c6bec4b26002814d25bd7cf16a372c252e904d9"
 python-versions = "^3.6"
 
 [metadata.hashes]
@@ -421,7 +422,7 @@ certifi = ["e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50", "
 chardet = ["84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae", "fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"]
 colorama = ["05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d", "f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"]
 cssselect = ["f612ee47b749c877ebae5bb77035d8f4202c6ad0f0fc1271b3c18ad6c4468ecf", "f95f8dedd925fd8f54edb3d2dfb44c190d9d18512377d3c1e2388d16126879bc"]
-delb = ["2f208f4d4a47195fd11bf102149601a6ac757ce11b5c2e18a4e551341e32ce3d", "63c124757f0eba7d12b99d71caf0f6cea8bd73331e52a77249764b7e7f92b8b9"]
+delb = ["8cd36a0cc6061b1b08c3ad602e3cef28e20f1cb1f12f29d68a85cf223aebb101", "abac7dcd447d8cedb8cbd4a51debbdbfbb5f5a37db59504e966b18f274107fc0"]
 docutils = ["6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0", "9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827", "a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"]
 idna = ["c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407", "ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"]
 imagesize = ["3f349de3eb99145973fefb7dbe38554414e5c30abd0c8e4b970a7c9d09f3a1d8", "f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ pytest = "^3.0"
 sphinx = "*"
 sphinx_rtd_theme = "^0.4.3"
 mypy = "^0.720.0"
+delb = {version = "^0.1.2",allows-prereleases = true}
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/snakesist/delb_plugin.py
+++ b/snakesist/delb_plugin.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+
+import pluggy
+
+
+class ExistResource:
+    def _init_config(self, config):
+        self.config.exist = SimpleNamespace(
+            client=config.pop("exist_client"),
+            absolute_id=config.pop("exist_absolute_id", None),
+            node_id=config.pop("exist_node_id", None),
+            document_path=config.pop("exist_document_path", None)
+        )
+        super()._init_config(config)
+
+    def update_pull(self):
+        """
+        Retrieve the current node state from the database and update the object.
+        # """
+        self.root = self.config.exist.client.retrieve_resource(
+            abs_resource_id=self.config.exist.absolute_id,
+            node_id=self.config.exist.node_id
+        ).root
+
+    def update_push(self):
+        self.config.exist.client.update_document(
+            data=str(self.root),
+            document_path=self.config.exist.document_path,
+        )
+
+    def delete(self):
+        self.config.exist.client.delete_document(document_path=self.config.exist.document_path)
+        self.config.exist.node_id = None
+        self.config.exist.absolute_id = None
+        self.config.exist.document_path = None
+
+
+@pluggy.HookimplMarker("delb")
+def get_document_extensions():
+    return ExistResource

--- a/tests/test_exist_client.py
+++ b/tests/test_exist_client.py
@@ -89,7 +89,7 @@ def test_exist_client_retrieve_resource(db):
     xq = "let $node := //example[@id='t6'] return util:absolute-resource-id($node)"
     abs_id = requests.get(f"{BASE_URL}&_query={xq}").content.decode()
     retrieved_node = db.retrieve_resource(abs_resource_id=abs_id)
-    assert new_node == str(retrieved_node)
+    assert new_node == str(retrieved_node.root)
 
 
 def test_exist_client_retrieve_resources(db):
@@ -99,6 +99,6 @@ def test_exist_client_retrieve_resources(db):
     document_resource = '<p>retrieve me too!</p>'
     db.create_resource("/foo", document_resource)
     retrieved_nodes = db.retrieve_resources("//p")
-    retrieved_nodes_str = [str(node) for node in retrieved_nodes]
+    retrieved_nodes_str = [str(node.root) for node in retrieved_nodes]
     assert node_resource in retrieved_nodes_str
     assert document_resource in retrieved_nodes_str

--- a/tests/test_exist_resource.py
+++ b/tests/test_exist_resource.py
@@ -1,0 +1,51 @@
+import pytest
+import requests
+
+from snakesist import ExistClient
+
+ROOT_COLL = "/db/tests"
+BASE_URL = f"http://admin:@localhost:8080/exist/rest{ROOT_COLL}?_wrap=no&_indent=no"
+
+
+@pytest.fixture
+def db():
+    """
+    Database setup and teardown
+    """
+    db = ExistClient()
+    db.root_collection = ROOT_COLL
+    yield db
+    requests.get(f"{BASE_URL}&_query=xmldb:remove('{ROOT_COLL}')")
+
+
+def test_exist_document_update_push(db):
+    new_node = '<example id="ta">wow a document node</example>'
+    db.create_resource("/foo", new_node)
+    updated_node = '<example id="ta">wow a document node???</example>'
+    doc = db.retrieve_resources("//example[@id='ta']").pop()
+    doc.root.append_child("???")
+    doc.update_push()
+    response = requests.get(f"{BASE_URL}&_query=//example[@id='ta']")
+    node = response.content.decode()
+    assert node == updated_node
+
+
+def test_exist_document_update_pull(db):
+    new_node = '<example id="tc">wow a document node</example>'
+    db.create_resource("/foo", new_node)
+    doc_1 = db.retrieve_resources("//example[@id='tc']").pop()
+    doc_2 = db.retrieve_resources("//example[@id='tc']").pop()
+    doc_1.root.append_child("???")
+    doc_1.update_push()
+    doc_2.update_pull()
+    assert str(doc_1.root) == str(doc_2.root)
+
+
+def test_exist_document_delete(db):
+    new_node = '<example id="tb">wow a document node</example>'
+    db.create_resource("/foo", new_node)
+    doc = db.retrieve_resources("//example[@id='tb']").pop()
+    doc.delete()
+    response = requests.get(f"{BASE_URL}&_query=//example[@id='tb']")
+    node = response.content.decode()
+    assert node == ""


### PR DESCRIPTION
~This PR roughly implements the [plugin mechanics planned for `delb` 0.2](https://github.com/funkyfuture/delb/pull/6). This is a draft for now and must be amended, refactored and reviewed. The base class representing an eXist resource has been rewritten as an extension class of `delb.Document`.~ 

**TODO**:
- [ ] ~Add type hints where missing~
- [ ] ~Review default parameter values and amend where appropriate~
- [ ] ~Reflect on overall structure and check with @funkyfuture if the implementation architecture is proper~

**LE**: This feature has been reconsidered, see [below](https://github.com/03b8/snakesist/pull/12#issuecomment-568498726).