### PR TITLE
Tests for a delb plugin implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
     - "3.6"
 before_install:
     - docker pull existdb/existdb:4.7.1
-    - docker run -it -d -p 8080:8080 -p 8443:8443 --name exist-4.7.1 existdb/existdb:4.7.1
+    - docker run -d -p 8080:8080 -p 8443:8443 --name exist-4.7.1 existdb/existdb:4.7.1
 install:
     - travis_retry pip install poetry
     - travis_retry poetry install

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+import requests
+from pytest import fixture
+
+from snakesist import ExistClient
+
+
+ROOT_COLL = "/db/tests"
+
+
+@fixture
+def base_url():
+    return f"http://admin:@localhost:8080/exist/rest{ROOT_COLL}?_wrap=no&_indent=no"
+
+
+@fixture
+def db(base_url):
+    """
+    Database setup and teardown
+    """
+    db = ExistClient()
+    db.root_collection = ROOT_COLL
+    yield db
+    requests.get(f"{base_url}&_query=xmldb:remove('{ROOT_COLL}')")

--- a/tests/test_delb_plugin.py
+++ b/tests/test_delb_plugin.py
@@ -1,0 +1,66 @@
+import pytest
+
+
+from delb import Document
+from snakesist import ExistClient
+
+
+@pytest.mark.usefixtures("db")
+def test_delete_document():
+    url = "existdb://admin:@localhost:8080/test_collection/test_document.xml"
+    document = Document(url)
+    document.existdb_delete()
+
+
+@pytest.mark.usefixtures("db")
+def test_load_document_from_url():
+    url = "existdb://admin:@localhost:8080/test_collection/test_document.xml"
+    document = Document(url)
+
+    assert document.config.source_url == url
+    assert isinstance(document.config.existdb.abs_id, str)
+    assert isinstance(document.config.existdb.client, ExistClient)
+    assert document.existdb_collection == "/test_collection/"
+    assert document.existdb_filename == "test_document.xml"
+
+
+@pytest.mark.usefixtures("db")
+def test_load_document_with_client():
+    exist_client = ExistClient(host="localhost", port=8080, user="admin", password="")
+    document = Document(
+        "/test_collection/test_document.xml", existdb_client=exist_client
+    )
+
+    assert (
+        document.config.source_url
+        == "existdb://admin:@localhost:8080/test_collection/test_document.xml"
+    )  # really??
+    assert isinstance(document.config.existdb.abs_id, str)
+    assert document.config.existdb.client is exist_client
+    assert document.existdb_collection == "/test_collection/"
+    assert document.existdb_filename == "test_document.xml"
+
+
+@pytest.mark.usefixtures("db")
+def test_store_document():
+    document = Document(
+        "<test/>",
+        existdb_client=ExistClient(
+            host="localhost", port=8080, user="admin", password="")
+    )
+    document.existdb_store(collection="/test_collection/", filename="new_document.xml")
+
+    document = Document(
+        "existdb://admin:@localhost:8080/test_collection/test_document.xml"
+    )
+    document.existdb_store(replace_existing=True)
+    document.existdb_store(
+        collection="/another/collection/",
+        filename="another_name.xml",
+    )
+    assert document.existdb_collection == "/test_collection/"
+    assert document.existdb_filename == "test_document.xml"
+
+    document.existdb_collection = "/another/collection/"
+    document.existdb_filename = "another_name.xml"
+    document.existdb_store(replace_existing=True)

--- a/tests/test_exist_client.py
+++ b/tests/test_exist_client.py
@@ -1,27 +1,12 @@
 import pytest
 import requests
 from requests.exceptions import HTTPError
-from snakesist import ExistClient
-
-ROOT_COLL = "/db/tests"
-BASE_URL = f"http://admin:@localhost:8080/exist/rest{ROOT_COLL}?_wrap=no&_indent=no"
 
 
-@pytest.fixture
-def db():
-    """
-    Database setup and teardown
-    """
-    db = ExistClient()
-    db.root_collection = ROOT_COLL
-    yield db
-    requests.get(f"{BASE_URL}&_query=xmldb:remove('{ROOT_COLL}')")
-
-
-def test_exist_client_create_resource_wellformed(db):
+def test_exist_client_create_resource_wellformed(base_url, db):
     new_node = '<example id="t1">wow a <foo>document</foo> node</example>'
     db.create_resource("/foo", new_node)
-    response = requests.get(f"{BASE_URL}&_query=//example[@id='t1']")
+    response = requests.get(f"{base_url}&_query=//example[@id='t1']")
     node = response.content.decode()
     assert node == new_node
 
@@ -32,62 +17,62 @@ def test_exist_client_create_resource_malformed(db):
         db.create_resource("/foo", new_node)
 
 
-def test_exist_client_update_document(db):
+def test_exist_client_update_document(base_url, db):
     new_node = '<example id="t2">wow a document node</example>'
     updated_node = '<example id="t2">wow a NEW document node</example>'
     db.create_resource("/foo", new_node)
     xq = "let $node := //example[@id='t2'] return util:collection-name($node) || '/' || util:document-name($node)"
-    path = requests.get(f"{BASE_URL}&_query={xq}").content.decode()
+    path = requests.get(f"{base_url}&_query={xq}").content.decode()
     db.update_document(updated_node, path)
-    response = requests.get(f"{BASE_URL}&_query=//example[@id='t2']")
+    response = requests.get(f"{base_url}&_query=//example[@id='t2']")
     node = response.content.decode()
     assert node == updated_node
 
 
-def test_exist_client_update_node(db):
+def test_exist_client_update_node(base_url, db):
     new_node = '<example id="t3">i am a <subnode>child</subnode></example>'
     updated_node = '<subnode>child indeed</subnode>'
     db.create_resource("/foo", new_node)
     xq = "let $node := //subnode return util:absolute-resource-id($node)"
-    abs_res_id = requests.get(f"{BASE_URL}&_query={xq}").content.decode()
+    abs_res_id = requests.get(f"{base_url}&_query={xq}").content.decode()
     xq = "let $node := //subnode return util:node-id($node)"
-    node_id = requests.get(f"{BASE_URL}&_query={xq}").content.decode()
+    node_id = requests.get(f"{base_url}&_query={xq}").content.decode()
     db.update_node(updated_node, abs_res_id, node_id)
-    response = requests.get(f"{BASE_URL}&_query=//subnode")
+    response = requests.get(f"{base_url}&_query=//subnode")
     node = response.content.decode()
     assert node == updated_node
 
 
-def test_exist_client_delete_node(db):
+def test_exist_client_delete_node(base_url, db):
     new_node = '<example id="t4">i stay<deletee> and i am to be deleted</deletee></example>'
     remaining_node = '<example id="t4">i stay</example>'
     db.create_resource("/foo", new_node)
     xq = "let $node := //deletee return util:absolute-resource-id($node)"
-    abs_res_id = requests.get(f"{BASE_URL}&_query={xq}").content.decode()
+    abs_res_id = requests.get(f"{base_url}&_query={xq}").content.decode()
     xq = "let $node := //deletee return util:node-id($node)"
-    node_id = requests.get(f"{BASE_URL}&_query={xq}").content.decode()
+    node_id = requests.get(f"{base_url}&_query={xq}").content.decode()
     db.delete_node(abs_res_id, node_id)
-    response = requests.get(f"{BASE_URL}&_query=//example[@id='t4']")
+    response = requests.get(f"{base_url}&_query=//example[@id='t4']")
     node = response.content.decode()
     assert node == remaining_node
 
 
-def test_exist_client_delete_document(db):
+def test_exist_client_delete_document(base_url, db):
     new_node = '<example id="t5">i am to be deleted</example>'
     db.create_resource("/foo", new_node)
     xq = "let $node := //example[@id='t5'] return util:collection-name($node) || '/' || util:document-name($node)"
-    path = requests.get(f"{BASE_URL}&_query={xq}").content.decode()
+    path = requests.get(f"{base_url}&_query={xq}").content.decode()
     db.delete_document(path)
-    response = requests.get(f"{BASE_URL}&_query=//example[@id='t5']")
+    response = requests.get(f"{base_url}&_query=//example[@id='t5']")
     node = response.content.decode()
     assert node == ""
 
 
-def test_exist_client_retrieve_resource(db):
+def test_exist_client_retrieve_resource(base_url, db):
     new_node = '<example id="t6">retrieve me!</example>'
     db.create_resource("/foo", new_node)
     xq = "let $node := //example[@id='t6'] return util:absolute-resource-id($node)"
-    abs_id = requests.get(f"{BASE_URL}&_query={xq}").content.decode()
+    abs_id = requests.get(f"{base_url}&_query={xq}").content.decode()
     retrieved_node = db.retrieve_resource(abs_resource_id=abs_id)
     assert new_node == str(retrieved_node)
 


### PR DESCRIPTION
as we discussed a few months back, here's a proposal how the api of a delb Document extension might look like.

i'm already puzzled about that prefix (usually `exist`) that a database instance would often use to be adressed. technically it part of the ur*l*, but one cannot distinguish what parts of the url are that prefix and the collection path. would there be a reliable way to probe that?

so i left that prefix out of the url scheme deliberately. though it should probably be contained.

be reminded that i'm absolutely naive here.