### PR TITLE
Adds test to lay out semantics and behaviour for a delb plugin

### DIFF
--- a/docs/api_doc.rst
+++ b/docs/api_doc.rst
@@ -10,6 +10,6 @@ Database Client
 Resources
 ---------
 
-.. autoclass:: snakesist.DocumentResource
+.. autoclass:: snakesist.delb_plugins.ExistDBExtension
 
 .. autoclass:: snakesist.NodeResource

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,9 @@ master_doc = 'index'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc'
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
 ]
 
 source_suffix = '.rst'
@@ -46,6 +48,10 @@ templates_path = ['_templates']
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
+
+intersphinx_mapping = {
+    'delb': ('https://delb.readthedocs.io/en/latest/', None),
+}
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/poetry.lock
+++ b/poetry.lock
@@ -76,12 +76,13 @@ category = "main"
 description = "A library that provides an ergonomic model for XML encoded text documents (e.g. with TEI-XML)."
 name = "delb"
 optional = false
-python-versions = ">=3.6"
-version = "0.1.2"
+python-versions = ">=3.6,<4.0"
+version = "0.2b3"
 
 [package.dependencies]
 cssselect = "*"
 lxml = "*"
+setuptools = "*"
 
 [package.extras]
 https-loader = ["requests (>=2.21,<3.0)"]
@@ -190,7 +191,7 @@ dmypy = ["psutil (>=4.0)"]
 [[package]]
 category = "dev"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
-marker = "python_version >= \"3.8\" or python_version >= \"3.5\" and python_version < \"3.8\" and (python_version >= \"3.5\" and python_version < \"3.8.0b1\" or python_version >= \"3.8.0b1\")"
+marker = "python_version >= \"3.8\" or python_version >= \"3.5\" and python_version < \"3.8\" and (python_version >= \"3.5\" and python_version < \"3.8\" or python_version >= \"3.8\")"
 name = "mypy-extensions"
 optional = false
 python-versions = "*"
@@ -440,7 +441,7 @@ test = ["pytest", "flake8", "mypy"]
 [[package]]
 category = "dev"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
-marker = "python_version >= \"3.8\" or python_version >= \"3.5\" and python_version < \"3.8\" and (python_version >= \"3.5\" and python_version < \"3.8.0b1\" or python_version >= \"3.8.0b1\")"
+marker = "python_version >= \"3.8\" or python_version >= \"3.5\" and python_version < \"3.8\" and (python_version >= \"3.5\" and python_version < \"3.8\" or python_version >= \"3.8\")"
 name = "typed-ast"
 optional = false
 python-versions = "*"
@@ -449,7 +450,7 @@ version = "1.4.0"
 [[package]]
 category = "dev"
 description = "Type Hints for Python"
-marker = "python_version >= \"3.8\" or python_version >= \"3.5\" and python_version < \"3.8\" and (python_version >= \"3.5\" and python_version < \"3.8.0b1\" or python_version >= \"3.8.0b1\")"
+marker = "python_version >= \"3.8\" or python_version >= \"3.5\" and python_version < \"3.8\" and (python_version >= \"3.5\" and python_version < \"3.8\" or python_version >= \"3.8\") and (python_version >= \"3.8\" or python_version >= \"3.5\" and python_version < \"3.8\" and (python_version >= \"3.5\" and python_version < \"3.8.0b1\" or python_version >= \"3.8.0b1\"))"
 name = "typing"
 optional = false
 python-versions = "*"
@@ -458,7 +459,7 @@ version = "3.7.4.1"
 [[package]]
 category = "dev"
 description = "Backported and Experimental Type Hints for Python 3.5+"
-marker = "python_version >= \"3.8\" or python_version >= \"3.5\" and python_version < \"3.8\" and (python_version >= \"3.5\" and python_version < \"3.8.0b1\" or python_version >= \"3.8.0b1\")"
+marker = "python_version >= \"3.8\" or python_version >= \"3.5\" and python_version < \"3.8\" and (python_version >= \"3.5\" and python_version < \"3.8\" or python_version >= \"3.8\")"
 name = "typing-extensions"
 optional = false
 python-versions = "*"
@@ -497,7 +498,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "contextlib2", "unittest2"]
 
 [metadata]
-content-hash = "5e286b53328772d54ffb100ca1aa2a29974e312b6ec624b3882a8589dac64ca0"
+content-hash = "7198d0cf9f070bf3d2177323efc7c86f71fd40dfbef844c4a69cbee238bdcc11"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -534,8 +535,8 @@ cssselect = [
     {file = "cssselect-1.1.0.tar.gz", hash = "sha256:f95f8dedd925fd8f54edb3d2dfb44c190d9d18512377d3c1e2388d16126879bc"},
 ]
 delb = [
-    {file = "delb-0.1.2-py3-none-any.whl", hash = "sha256:2f208f4d4a47195fd11bf102149601a6ac757ce11b5c2e18a4e551341e32ce3d"},
-    {file = "delb-0.1.2.tar.gz", hash = "sha256:63c124757f0eba7d12b99d71caf0f6cea8bd73331e52a77249764b7e7f92b8b9"},
+    {file = "delb-0.2b3-py3-none-any.whl", hash = "sha256:c44fafb860f64da45131cec73158fbfaa75e27dcc34cdee96550bb5e94b3660c"},
+    {file = "delb-0.2b3.tar.gz", hash = "sha256:7bf03ab3ac9d3eff03c7a8501de867d3543013f04c2b7b9ece966a2a5d144bf1"},
 ]
 docutils = [
     {file = "docutils-0.15.2-py2-none-any.whl", hash = "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = ["xml", "exist-db", "client"]
 
 [tool.poetry.dependencies]
 python = "^3.6"
-delb = "^0.1"
+delb = "^0.2b3"
 requests = "^2.22"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ classifiers = [
 ]
 keywords = ["xml", "exist-db", "client"]
 
+[tool.poetry.plugins.delb]
+snakesist = "snakesist.delb_plugins"
+
 [tool.poetry.dependencies]
 python = "^3.6"
 delb = "^0.2b3"

--- a/snakesist/delb_plugins.py
+++ b/snakesist/delb_plugins.py
@@ -1,0 +1,87 @@
+from types import SimpleNamespace
+from typing import Any, Dict
+
+from delb.plugins import plugin_manager, DocumentExtensionHooks
+from delb.typing import LoaderResult
+
+
+@plugin_manager.register_loader()
+def existdb_loader(source: Any, config: SimpleNamespace) -> LoaderResult:
+    raise NotImplemented
+
+
+@plugin_manager.register_document_extension
+class ExistDBExtension(DocumentExtensionHooks):
+    """
+    This class provides extensions to :class:`delb.Document` in order to interact
+    with a eXist-db instance.
+
+    Documents can be loaded from an eXist-db instance by either specifying an URL with
+    the ``existdb://`` scheme or by specifying a path made up of a collection path and
+    a filename and passing a :class:`snakesist.ExistClient` instance with the
+    ``existdb_client`` keyword. These two initializations would yield the same
+    :class:`delb.Document`:
+
+    .. code-block::
+
+        import delb
+        import snakesist
+
+        # with an URL
+        document = delb.Document(
+            "existdb://example.exist-host.org/exist/collection/document.xml"
+        )
+
+        # with a client
+        client = snakesist.ExistClient(
+            host="example.exist-host.org",
+            prefix="exist",
+        )
+        document = delb.Document("/collection/document.xml", existdb_client=client)
+    """
+
+    def _init_config(self, config_args: Dict[str, Any]):
+        raise NotImplemented
+        super()._init_config(config_args)
+
+    @property
+    def existdb_collection(self):
+        """
+        The collection within an eXist-db instance where the document was fetched from.
+        This property can be changed to designate another location to store to.
+        """
+        raise NotImplemented
+
+    @existdb_collection.setter
+    def existdb_collection(self, collection: str):
+        raise NotImplemented
+
+    def existdb_delete(self):
+        """
+        Deletes the document that currently resides at the location which is made up of
+        the current ``existdb_collection`` and ``existdb_filename`` in the associated
+        eXist-db instance.
+        """
+        raise NotImplemented
+
+    @property
+    def existdb_filename(self):
+        """
+        The filename within the eXist-db instance and collection where the document was
+        fetched from.
+        This property can be changed to designate another location to store to.
+        """
+        raise NotImplemented
+
+    @existdb_filename.setter
+    def existdb_filename(self, filename: str):
+        raise NotImplemented
+
+    def existdb_store(self, collection: str = None, filename: str = None):
+        """
+        Stores the current state of the document in the associated eXist-db instance.
+
+        :param collection: An alternate collection to save into.
+        :param filename: An alternate name to store the document.
+        """
+        raise NotImplemented

--- a/tests/test_delb_plugin.py
+++ b/tests/test_delb_plugin.py
@@ -1,23 +1,24 @@
 import pytest
 
-
-from delb import Document
+from delb import Document, FailedDocumentLoading
 from snakesist import ExistClient
 
 
 @pytest.mark.usefixtures("db")
 def test_delete_document():
-    url = "existdb://admin:@localhost:8080/test_collection/test_document.xml"
+    url = "existdb://admin:@localhost:8080/exist/test_collection/test_document.xml"
     document = Document(url)
     document.existdb_delete()
+    with pytest.raises(FailedDocumentLoading):
+        Document(url)
 
 
 @pytest.mark.usefixtures("db")
 def test_load_document_from_url():
-    url = "existdb://admin:@localhost:8080/test_collection/test_document.xml"
+    url = "existdb://admin:@localhost:8080/exist/test_collection/test_document.xml"
     document = Document(url)
 
-    assert document.config.source_url == url
+    assert document.source_url == url
     assert isinstance(document.config.existdb.abs_id, str)
     assert isinstance(document.config.existdb.client, ExistClient)
     assert document.existdb_collection == "/test_collection/"
@@ -32,9 +33,9 @@ def test_load_document_with_client():
     )
 
     assert (
-        document.config.source_url
-        == "existdb://admin:@localhost:8080/test_collection/test_document.xml"
-    )  # really??
+        document.source_url
+        == "existdb://admin:@localhost:8080/exist/test_collection/test_document.xml"
+    )
     assert isinstance(document.config.existdb.abs_id, str)
     assert document.config.existdb.client is exist_client
     assert document.existdb_collection == "/test_collection/"
@@ -46,17 +47,17 @@ def test_store_document():
     document = Document(
         "<test/>",
         existdb_client=ExistClient(
-            host="localhost", port=8080, user="admin", password="")
+            host="localhost", port=8080, user="admin", password=""
+        ),
     )
     document.existdb_store(collection="/test_collection/", filename="new_document.xml")
 
     document = Document(
-        "existdb://admin:@localhost:8080/test_collection/test_document.xml"
+        "existdb://admin:@localhost:8080/exist/test_collection/test_document.xml"
     )
     document.existdb_store(replace_existing=True)
     document.existdb_store(
-        collection="/another/collection/",
-        filename="another_name.xml",
+        collection="/another/collection/", filename="another_name.xml",
     )
     assert document.existdb_collection == "/test_collection/"
     assert document.existdb_filename == "test_document.xml"

--- a/tests/test_delb_plugin.py
+++ b/tests/test_delb_plugin.py
@@ -1,0 +1,66 @@
+import pytest
+
+
+from delb import Document
+from snakesist import ExistClient
+
+
+@pytest.mark.usefixtures("db")
+def test_delete_document():
+    url = "existdb://admin:@localhost:8080/test_collection/test_document.xml"
+    document = Document(url)
+    document.existdb_delete()
+
+
+@pytest.mark.usefixtures("db")
+def test_load_document_from_url():
+    url = "existdb://admin:@localhost:8080/test_collection/test_document.xml"
+    document = Document(url)
+
+    assert document.config.source_url == url
+    assert isinstance(document.config.existdb.abs_id, str)
+    assert isinstance(document.config.existdb.client, ExistClient)
+    assert document.existdb_collection == "/test_collection/"
+    assert document.existdb_filename == "test_document.xml"
+
+
+@pytest.mark.usefixtures("db")
+def test_load_document_with_client():
+    exist_client = ExistClient(host="localhost", port=8080, user="admin", password="")
+    document = Document(
+        "/test_collection/test_document.xml", existdb_client=exist_client
+    )
+
+    assert (
+        document.config.source_url
+        == "existdb://admin:@localhost:8080/test_collection/test_document.xml"
+    )  # really??
+    assert isinstance(document.config.existdb.abs_id, str)
+    assert document.config.existdb.client is exist_client
+    assert document.existdb_collection == "/test_collection/"
+    assert document.existdb_filename == "test_document.xml"
+
+
+@pytest.mark.usefixtures("db")
+def test_store_document():
+    document = Document(
+        "<test/>",
+        existdb_client=ExistClient(
+            host="localhost", port=8080, user="admin", password="")
+    )
+    document.existdb_store(collection="/test_collection/", filename="new_document.xml")
+
+    document = Document(
+        "existdb://admin:@localhost:8080/test_collection/test_document.xml"
+    )
+    document.existdb_store(replace_existing=True)
+    document.existdb_store(
+        collection="/another/collection/",
+        filename="another_name.xml",
+    )
+    assert document.existdb_collection == "/test_collection/"
+    assert document.existdb_filename == "test_document.xml"
+
+    document.existdb_collection = "/another/collection/"
+    document.existdb_filename = "another_name.xml"
+    document.existdb_store(replace_existing=True)


### PR DESCRIPTION
this is a follow-up of #15, it serves the purpose to discuss a possible design of a [delb](delb.readthedocs.io/) plugin for existdb-stored documents as well as aspects of delb's data model and plugin system itself, the [specific docs](https://delb.readthedocs.io/en/latest/extending.html) include a link to a reference implementation of plugins. the goal here is to implement a loader as well as a document extension. 

---

as we discussed a few months back, here's a proposal how the api of a delb Document extension might look like.

i'm already puzzled about that prefix (usually `exist/`) that a database instance would often use to be adressed. technically it part of the UR**L**, but one cannot distinguish what parts of the url are that prefix and the collection path. would there be a reliable way to probe that?

so i left that prefix out of the url scheme deliberately. though it should probably be contained.

be reminded that i'm absolutely naive here.