### PR TITLE
Improvements on client props

### DIFF
--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -22,6 +22,7 @@ class QueryResultItem(NamedTuple):
 
 
 class ConnectionProps(NamedTuple):
+    transport: str
     user: str
     password: str
     host: str
@@ -29,6 +30,7 @@ class ConnectionProps(NamedTuple):
     prefix: str
 
 
+DEFAULT_TRANSPORT = "http"
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 8080
 DEFAULT_USER = "admin"
@@ -177,12 +179,14 @@ class ExistClient:
     :param user: username
     :param password: password
     :param prefix: configured path prefix for the eXist instance
-    :param root_collection: a path to a collection which will be used as root for all document paths
+    :param root_collection: a path to a collection which will be used as root for all
+                            document paths
     :param parser: an lxml etree.XMLParser instance to parse query results
     """
 
     def __init__(
         self,
+        transport: str = DEFAULT_TRANSPORT,
         host: str = DEFAULT_HOST,
         port: int = DEFAULT_PORT,
         user: str = DEFAULT_USER,
@@ -192,16 +196,14 @@ class ExistClient:
         parser: etree.XMLParser = DEFAULT_PARSER,
     ):
         self.__connection_props = ConnectionProps(
+            transport=transport,
             user=user,
             password=password,
             host=host,
             port=port,
             prefix=prefix,
         )
-        self._base_url = (
-            f"http://{self.user}:{self.password}"
-            f"@{self.host}:{self.port}/{self.prefix}"
-        )
+        self.__base_url = f"{transport}://{user}:{password}@{host}:{port}/{prefix}"
         self.parser = parser
         self._root_collection = root_collection
 
@@ -270,7 +272,7 @@ class ExistClient:
         """
         The base URL pointing to the eXist instance.
         """
-        return self._base_url
+        return self.__base_url
 
     @property
     def host(self):
@@ -320,7 +322,6 @@ class ExistClient:
         Set the path to the root collection for database
         queries (e. g. '/db/foo/bar/').
         """
-
         self._root_collection = collection
 
     @property
@@ -328,7 +329,6 @@ class ExistClient:
         """
         The URL pointing to the configured root collection.
         """
-
         data_path = self._join_paths("/rest/", self.root_collection)
         url = urljoin(self.base_url, data_path)
         return url

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -165,6 +165,7 @@ class ExistClient:
     :param user: username
     :param password: password
     :param prefix: configured path prefix for the eXist instance
+    :param root_collection: a path to a collection which will be used as root for all document paths
     :param parser: an lxml etree.XMLParser instance to parse query results
     """
 
@@ -175,9 +176,11 @@ class ExistClient:
             user: str = DEFAULT_USER,
             password: str = DEFAULT_PASSWORD,
             prefix: str = "exist",
+            root_collection: str = "/",
             parser: etree.XMLParser = DEFAULT_PARSER
+
     ):
-        self._root_collection = "/"
+        self._root_collection = root_collection
         self.host = host
         self.port = port
         self.user = user

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -230,7 +230,7 @@ class ExistClient:
             url,
             headers={"Content-Type": "application/xml"},
             auth=HTTPBasicAuth(
-                self.__connection_props.user, self.__connection_props.password
+                self.user, self.password
             ),
             params=params,
         )
@@ -244,7 +244,7 @@ class ExistClient:
             url,
             headers={"Content-Type": "application/xml"},
             auth=HTTPBasicAuth(
-                self.__connection_props.user, self.__connection_props.password
+                self.user, self.password
             ),
             data=data.encode("utf-8"),
         )
@@ -259,7 +259,7 @@ class ExistClient:
             url,
             headers={"Content-Type": "application/xml"},
             auth=HTTPBasicAuth(
-                self.__connection_props.user, self.__connection_props.password
+                self.user, self.password
             ),
         )
 

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -229,9 +229,7 @@ class ExistClient:
         response = requests.get(
             url,
             headers={"Content-Type": "application/xml"},
-            auth=HTTPBasicAuth(
-                self.user, self.password
-            ),
+            auth=HTTPBasicAuth(self.user, self.password),
             params=params,
         )
 
@@ -243,9 +241,7 @@ class ExistClient:
         response = requests.put(
             url,
             headers={"Content-Type": "application/xml"},
-            auth=HTTPBasicAuth(
-                self.user, self.password
-            ),
+            auth=HTTPBasicAuth(self.user, self.password),
             data=data.encode("utf-8"),
         )
 
@@ -258,9 +254,7 @@ class ExistClient:
         response = requests.delete(
             url,
             headers={"Content-Type": "application/xml"},
-            auth=HTTPBasicAuth(
-                self.user, self.password
-            ),
+            auth=HTTPBasicAuth(self.user, self.password),
         )
 
         if response.status_code != requests.codes.ok:

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -22,11 +22,10 @@ class QueryResultItem(NamedTuple):
 
 
 class ConnectionProps(NamedTuple):
-    root_collection: str
-    host: str
-    port: int
     user: str
     password: str
+    host: str
+    port: int
     prefix: str
 
 
@@ -193,21 +192,18 @@ class ExistClient:
         parser: etree.XMLParser = DEFAULT_PARSER,
     ):
         self.__connection_props = ConnectionProps(
-            root_collection=root_collection,
-            host=host,
-            port=port,
             user=user,
             password=password,
+            host=host,
+            port=port,
             prefix=prefix,
         )
         self._base_url = (
-            f"http://{self.__connection_props.user}"
-            f":{self.__connection_props.password}"
-            f"@{self.__connection_props.host}"
-            f":{self.__connection_props.port}"
-            f"/{self.__connection_props.prefix}"
+            f"http://{self.user}:{self.password}"
+            f"@{self.host}:{self.port}/{self.prefix}"
         )
         self.parser = parser
+        self._root_collection = root_collection
 
     @staticmethod
     def _join_paths(*args):
@@ -316,7 +312,7 @@ class ExistClient:
         """
         The configured root collection for database queries.
         """
-        return self.__connection_props.root_collection
+        return self._root_collection
 
     @root_collection.setter
     def root_collection(self, collection: str):
@@ -325,7 +321,7 @@ class ExistClient:
         queries (e. g. '/db/foo/bar/').
         """
 
-        self.__connection_props.root_collection = collection
+        self._root_collection = collection
 
     @property
     def root_collection_url(self):

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -181,11 +181,15 @@ class ExistClient:
 
     ):
         self._root_collection = root_collection
-        self.host = host
-        self.port = port
-        self.user = user
-        self.password = password
-        self.prefix = prefix
+        self._host = host
+        self._port = port
+        self._user = user
+        self._password = password
+        self._prefix = prefix
+        self._base_url = (
+            f"http://{self._user}:{self._password}@{self._host}:{self._port}"
+            f"/{self._prefix}"
+        )
         self.parser = parser
 
     @staticmethod
@@ -204,7 +208,7 @@ class ExistClient:
         response = requests.get(
             url,
             headers={"Content-Type": "application/xml"},
-            auth=HTTPBasicAuth(self.user, self.password),
+            auth=HTTPBasicAuth(self._user, self._password),
             params=params
         )
 
@@ -216,7 +220,7 @@ class ExistClient:
         response = requests.put(
             url,
             headers={"Content-Type": "application/xml"},
-            auth=HTTPBasicAuth(self.user, self.password),
+            auth=HTTPBasicAuth(self._user, self._password),
             data=data.encode("utf-8")
         )
 
@@ -229,7 +233,7 @@ class ExistClient:
         response = requests.delete(
             url,
             headers={"Content-Type": "application/xml"},
-            auth=HTTPBasicAuth(self.user, self.password),
+            auth=HTTPBasicAuth(self._user, self._password),
         )
 
         if response.status_code != requests.codes.ok:
@@ -247,10 +251,42 @@ class ExistClient:
         """
         The base URL pointing to the eXist instance.
         """
-        return (
-            f"http://{self.user}:{self.password}@{self.host}:{self.port}"
-            f"/{self.prefix}"
-        )
+        return self._base_url
+
+    @property
+    def host(self):
+        """
+        The database hostname
+        """
+        return self._host
+
+    @property
+    def port(self):
+        """
+        The database port number
+        """
+        return self._port
+
+    @property
+    def user(self):
+        """
+        The user name used to connect to the database
+        """
+        return self._user
+
+    @property
+    def password(self):
+        """
+        The password used to connect to the database
+        """
+        return self._password
+
+    @property
+    def prefix(self):
+        """
+        The URL prefix of the database
+        """
+        return self._prefix
 
     @property
     def root_collection(self) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ from snakesist import ExistClient
 
 @fixture
 def rest_base_url(test_client):
-    test_client.root_collection = "/db/tests"
     return (
         f"{test_client.base_url}rest{test_client.root_collection}?_wrap=no&_indent=no"
     )
@@ -45,6 +44,11 @@ def docker_compose_file(pytestconfig):
 def test_client(db):
     host, port = db[len("http://") :].split(":")
     client = ExistClient(
-        host=host, port=int(port), prefix="exist/", user="admin", password="",
+        host=host,
+        port=int(port),
+        prefix="exist/",
+        user="admin",
+        password="",
+        root_collection="/db/tests",
     )
     yield client


### PR DESCRIPTION
This addresses #22 and #24 by making db connection props read-only, putting them in a namedtuple and allowing for `root_collection` to be passed at client instantiation.